### PR TITLE
Fix(Invoice): Correct invoice calculation to use current reading

### DIFF
--- a/acueducto/views.py
+++ b/acueducto/views.py
@@ -119,7 +119,13 @@ def generar_pdf_factura(usuario, fecha_emision, periodo_facturacion, base_url):
         consumo_m3 = 0
 
     valor_por_m3 = 1000
-    costo_consumo_raw = consumo_m3 * valor_por_m3
+    
+    # Calculate costo_consumo_raw based on usuario.lectura
+    if usuario.lectura is not None:
+        costo_consumo_raw = usuario.lectura * valor_por_m3
+    else:
+        costo_consumo_raw = 0
+        
     costo_consumo_agua_redondeado = round(costo_consumo_raw)
 
     credito = usuario.credito if usuario.credito is not None else 0


### PR DESCRIPTION
The invoice generation was previously using the difference between the current and previous meter readings to calculate the base water cost. This commit corrects the logic in `acueducto/views.py` within the `generar_pdf_factura` function.

The `costo_consumo_raw` is now calculated as `usuario.lectura * valor_por_m3` (current reading multiplied by the price per m³), regardless of whether a previous reading exists. The `consumo_m3` variable, which represents the difference in consumption, is preserved for display purposes on the invoice template but is no longer used for the primary cost calculation.

Additionally, the existing tests in `acueducto/tests.py` have been updated, and new tests (`test_invoice_calculation_with_previous_reading_new_logic` and `test_invoice_calculation_no_previous_reading_new_logic`) have been added to ensure the new logic is correctly implemented and verified for scenarios with and without previous readings. The invoice template `factura_template.html` was verified to correctly display the values based on the updated logic without requiring changes.