### PR TITLE
Fix: Add numero_de_medidor to UserAcueducto model

### DIFF
--- a/acueducto/models.py
+++ b/acueducto/models.py
@@ -22,6 +22,7 @@ class UserAcueducto(models.Model):
     credito_descripcion = models.TextField(blank=True)
     otros_gastos_valor = models.DecimalField(max_digits=10, decimal_places=2, default=0)
     otros_gastos_descripcion = models.TextField(blank=True)
+    numero_de_medidor = models.CharField(max_length=50, blank=True, null=True, unique=True)
 
     def __str__(self):
         return f"{self.name} {self.lastname} - {self.contrato}"


### PR DESCRIPTION
The `numero_de_medidor` field was missing from the `UserAcueducto` model in `acueducto/models.py`, causing a `SystemCheckError` in the Django admin when `UsersAcueductoAdmin` tried to display it.

This commit adds the `numero_de_medidor` field to the model, consistent with the definition in migration `0009_useracueducto_numero_de_medidor.py`. This resolves the admin error.